### PR TITLE
Update broken link (to Python chapter) in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@ The fact is that <strong>R</strong> has a <strong>lot</strong> to offer as well.
 </ul>
 <p>Moreover, via the <em>reticulate</em> package, it is possible (but not always easy) to benefit from Python tools as well. The most prominent example is the adaptation of the <em>tensorflow</em> and <em>keras</em> libraries to R. Thus, some very advanced Python material is readily available to R users. This is also true for other resources, like Stanford’s CoreNLP library (in Java) which was adapted to R in the package <em>coreNLP</em> (which we will not use in this book).</p>
 </div>
-Nevertheless, the Python version of the book can be found in <a href="https//www.mlfactor.com/python.html">Chapter 18</a>.  
+Nevertheless, the Python version of the book can be found in <a href="http://www.mlfactor.com/python.html">Chapter 18</a>.  
 <div id="coding-instructions" class="section level2 unnumbered">
 <h2>Coding instructions<a class="anchor" aria-label="anchor" href="#coding-instructions"><i class="fas fa-link"></i></a>
 <a class="anchor" aria-label="anchor" href="#coding-instructions"><i class="fas fa-link"></i></a>


### PR DESCRIPTION
First of all, thanks for the great book - a pleasure to read.

I discovered that a link to the Python chapter is not working - see below. However, I'm not sure if this should be corrected directly in the html file or if those files are generated from notebooks/markdown-files.

Some feedback: For me, it would have been helpful to have all the code in one place to enable non-linear reading of the book, i.e. "code first - read later" (e.g. in an appendix, see: [rmarkdown cookbook](https://bookdown.org/yihui/rmarkdown-cookbook/code-appendix.html)).
 
If this is something you would consider, I would be happy to support.
